### PR TITLE
Allow id on select options

### DIFF
--- a/projects/ng-select2-component/src/lib/select2-utils.ts
+++ b/projects/ng-select2-component/src/lib/select2-utils.ts
@@ -11,6 +11,7 @@ export interface Select2Option {
     label: string;
     disabled?: boolean;
     component?: string | Function;
+    id?: string;
     classes?: string;
 }
 

--- a/projects/ng-select2-component/src/lib/select2.component.html
+++ b/projects/ng-select2-component/src/lib/select2.component.html
@@ -76,15 +76,16 @@
                     role="tree"
                     tabindex="-1"
                     (keydown)="keyDown($event)">
-                    <ng-container *ngFor="let groupOrOption of filteredData; trackBy:trackBy">
+                    <ng-container *ngFor="let groupOrOption of filteredData; index as i; trackBy:trackBy">
                         <li *ngIf="groupOrOption.options"
                             class="select2-results__option"
                             role="group">
                             <strong [attr.class]="'select2-results__group' + (groupOrOption.classes ? ' ' + groupOrOption.classes : '')"
                                     [innerHTML]="groupOrOption.label"></strong>
                             <ul class="select2-results__options select2-results__options--nested">
-                                <li *ngFor="let option of groupOrOption.options; trackBy:trackBy"
+                                <li *ngFor="let option of groupOrOption.options; index as j; trackBy:trackBy"
                                     #result
+                                    [id]="option.id || id + '-option-' + i + '-' + j"
                                     [class]="getOptionStyle(option)"
                                     role="treeitem"
                                     [attr.aria-selected]="isSelected(option)"
@@ -96,6 +97,7 @@
                         </li>
                         <li *ngIf="!groupOrOption.options"
                             #result
+                            [id]="groupOrOption.id || id + '-option-' + i"
                             [class]="getOptionStyle(groupOrOption)"
                             role="treeitem"
                             [attr.aria-selected]="isSelected(groupOrOption)"

--- a/projects/ng-select2-component/src/lib/select2.component.ts
+++ b/projects/ng-select2-component/src/lib/select2.component.ts
@@ -256,7 +256,7 @@ export class Select2 implements ControlValueAccessor, OnInit, OnDestroy, DoCheck
     getOptionStyle(option: Select2Option) {
         return 'select2-results__option ' +
             (option.value === this.hoveringValue ? 'select2-results__option--highlighted ' : '') +
-            option.classes;
+            (option.classes || '');
     }
 
     mouseenter(option: Select2Option) {

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -69,14 +69,14 @@
     background-color: antiquewhite;
 }
 
-::ng-deep .white.flower::before {
+.flower-list ::ng-deep .white.flower::before {
     content: "🌼 ";
 }
 
-::ng-deep .red.flower::before {
+.flower-list ::ng-deep .red.flower::before {
     content: "🌹 ";
 }
 
-::ng-deep .yellow.flower::before {
+.flower-list ::ng-deep .yellow.flower::before {
     content: "🌻 ";
 }

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -68,3 +68,15 @@
 .noStyle {
     background-color: antiquewhite;
 }
+
+::ng-deep .white.flower::before {
+    content: "🌼 ";
+}
+
+::ng-deep .red.flower::before {
+    content: "🌹 ";
+}
+
+::ng-deep .yellow.flower::before {
+    content: "🌻 ";
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -175,7 +175,7 @@
     <button (click)="value21 = ''">Update value to empty string</button>
     <button (click)="value21 = null">Update value to null</button>
     <button (click)="value21 = undefined">Update value to undefined</button>
-    <h3>22. with item classes ({{value22}})</h3>
+    <h3>22. with item classes and id ({{value22}})</h3>
     <select2 [data]="data22"
              [value]="value22"
              (update)="update22($event)"

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -180,6 +180,7 @@
              [value]="value22"
              (update)="update22($event)"
              listPosition="above"
-             id="selec2-22">
+             id="selec2-22"
+             class="flower-list">
     </select2>
 </div>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -175,4 +175,11 @@
     <button (click)="value21 = ''">Update value to empty string</button>
     <button (click)="value21 = null">Update value to null</button>
     <button (click)="value21 = undefined">Update value to undefined</button>
+    <h3>22. with item classes ({{value22}})</h3>
+    <select2 [data]="data22"
+             [value]="value22"
+             (update)="update22($event)"
+             listPosition="above"
+             id="selec2-22">
+    </select2>
 </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 
-import { data1, data13, data17, data18, data19, data2, data3, data5 } from './app.data';
+import { data1, data13, data17, data18, data19, data2, data22, data3, data5 } from './app.data';
 
 import { Select2Data, Select2Option, Select2UpdateEvent } from 'projects/ng-select2-component/src/lib/select2-utils';
 
@@ -31,6 +31,7 @@ export class AppComponent {
     data19 = data19;
     data20: Select2Data = JSON.parse(JSON.stringify(data19));
     data21: Select2Data = JSON.parse(JSON.stringify(data19));
+    data22 = data22;
 
     minCountForSearch = Infinity;
 
@@ -56,6 +57,7 @@ export class AppComponent {
     value19 = '';
     value20 = '';
     value21 = 'foo6';
+    value22 = '';
 
     limitSelection = 0;
 
@@ -178,6 +180,10 @@ export class AppComponent {
 
     update21(event: Select2UpdateEvent<string>) {
         this.value21 = event.value;
+    }
+
+    update22(event: Select2UpdateEvent<string>) {
+        this.value22 = event.value;
     }
 
     resetForm() {

--- a/src/app/app.data.ts
+++ b/src/app/app.data.ts
@@ -219,10 +219,10 @@ export const data17: Select2Data = [
 ];
 
 export const data22: Select2Data = [
-    { value: 'heliotrope', label: 'Heliotrope', classes: 'white flower' },
-    { value: 'hibiscus', label: 'Hibiscus', classes: 'red flower' },
-    { value: 'lily', label: 'Lily', classes: 'white flower' },
-    { value: 'marigold', label: 'Marigold', classes: 'red flower' },
-    { value: 'petunia', label: 'Petunia', classes: 'white flower' },
-    { value: 'sunflower', label: 'Sunflower', classes: 'yellow flower' },
+    { value: 'heliotrope', label: 'Heliotrope', classes: 'white flower', id: 'option-heliotrope' },
+    { value: 'hibiscus', label: 'Hibiscus', classes: 'red flower', id: 'option-hibiscus' },
+    { value: 'lily', label: 'Lily', classes: 'white flower', id: 'option-lily' },
+    { value: 'marigold', label: 'Marigold', classes: 'red flower', id: 'option-marigold' },
+    { value: 'petunia', label: 'Petunia', classes: 'white flower', id: 'option-petunia' },
+    { value: 'sunflower', label: 'Sunflower', classes: 'yellow flower', id: 'option-sunflower' }
 ];

--- a/src/app/app.data.ts
+++ b/src/app/app.data.ts
@@ -217,3 +217,12 @@ export const data17: Select2Data = [
                 </div>`
     }
 ];
+
+export const data22: Select2Data = [
+    { value: 'heliotrope', label: 'Heliotrope', classes: 'white flower' },
+    { value: 'hibiscus', label: 'Hibiscus', classes: 'red flower' },
+    { value: 'lily', label: 'Lily', classes: 'white flower' },
+    { value: 'marigold', label: 'Marigold', classes: 'red flower' },
+    { value: 'petunia', label: 'Petunia', classes: 'white flower' },
+    { value: 'sunflower', label: 'Sunflower', classes: 'yellow flower' },
+];


### PR DESCRIPTION
# New
Added an id on the select options.
Allow to give a specific id to an option via `Select2Option` config.

# Bugfix
Remove the `undefined` class wrongly added to options when `classes` is not defined on `Select2Option`.