### PR TITLE
Fix css outline

### DIFF
--- a/projects/ng-select2-component/src/lib/select2.component.scss
+++ b/projects/ng-select2-component/src/lib/select2.component.scss
@@ -339,7 +339,7 @@
         .select2-selection--multiple {
             border: solid #000 1px;
             border: solid var(--select2-selection-focus-border-color, #000) 1px;
-            outline: 0;
+            outline: none;
         }
     }
 
@@ -348,7 +348,7 @@
         .select2-selection--multiple {
             border: solid #000 1px;
             border: solid var(--select2-selection-focus-border-color, #000) 1px;
-            outline: 0;
+            outline: none;
         }
     }
 
@@ -395,7 +395,7 @@
         .select2-search__field {
             background: transparent;
             border: none;
-            outline: 0;
+            outline: none;
             box-shadow: none;
             -webkit-appearance: textfield;
         }


### PR DESCRIPTION
The `outline` set `0` gives the boxes a blue border which doesn't look nice. Better to set them to `none`.

![Screen Shot 2020-11-01 at 22 25 37](https://user-images.githubusercontent.com/6447444/97815885-90328e00-1c91-11eb-8e24-d915908ffca3.png)
![Screen Shot 2020-11-01 at 22 25 24](https://user-images.githubusercontent.com/6447444/97815886-9163bb00-1c91-11eb-893c-8ef06285eb72.png)
