### PR TITLE
also call markForCheck() when the filtereddata is set 

### DIFF
--- a/projects/ng-select2-component/src/lib/select2.component.ts
+++ b/projects/ng-select2-component/src/lib/select2.component.ts
@@ -370,6 +370,7 @@ export class Select2 implements ControlValueAccessor, OnInit, OnDestroy, DoCheck
             }
 
             this.filteredData = result;
+            this._changeDetectorRef.markForCheck();
         });
     }
 


### PR DESCRIPTION
When the component is used in a parent where the change detection is set to Push then the first time the popup is show is not showing any results or items
this is because angular doesn't see these changes.
Make sure changeDetectorRef.markForCheck() is called just as in a few other places so that change is picked up.