### PR TITLE
Fixed default Padding

### DIFF
--- a/projects/ng-select2-component/src/lib/select2.component.scss
+++ b/projects/ng-select2-component/src/lib/select2.component.scss
@@ -25,7 +25,7 @@
 
         .select2-selection__rendered {
             display: block;
-            padding: 0 0 0 8px;
+            padding: 3px 0 0 8px;
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;

--- a/projects/ng-select2-component/src/lib/select2.component.scss
+++ b/projects/ng-select2-component/src/lib/select2.component.scss
@@ -290,7 +290,7 @@
             box-sizing: border-box;
             list-style: none;
             margin: 0;
-            padding: 0 5px;
+            padding: 3px 0 0 5px;
             width: 100%;
 
             li {


### PR DESCRIPTION
Fixed default padding so the tag badges and text aren't right on the top of the input but centered.

Top is with the fix, bottom is without:
![image](https://github.com/Harvest-Dev/ng-select2/assets/735851/fc9840bf-1120-427d-a12d-8ddec8e79cae)
