### PR TITLE
fix: issue with input when you hit spacebar on auto create mode, it doesn't allow spaces

### DIFF
--- a/projects/ng-select2-component/src/lib/select2.component.ts
+++ b/projects/ng-select2-component/src/lib/select2.component.ts
@@ -1089,9 +1089,11 @@ export class Select2 implements ControlValueAccessor, OnInit, DoCheck, AfterView
         } else if (this._testKey(event, ['PageDown'])) {
             this.moveDown(10);
             this.actionAfterKeyDownMoveAction(event);
-        } else if (this._testKey(event, ['Enter']) || (this.isSearchboxHidden && this._testKey(event, [' ']))) {
+        } else if (this._testKey(event, ['Enter'])) {
             this.selectByEnter(true);
             event.preventDefault();
+        } else if(this.isSearchboxHidden && this._testKey(event, [' '])) {
+           return;
         } else if (this._testKey(event, CLOSE_KEYS) && this.isOpen) {
             this.toggleOpenAndClose();
             this._focus(true);


### PR DESCRIPTION
There is an issue when a user hits spacebar when typing in the input that is not the search box, the focus suddenly shifts to another box instead of allowing the user to type spaces in the box