### PR TITLE
fix: use this.prevChange to ensure that  hitting space bar doesn't shift focus

### DIFF
--- a/projects/ng-select2-component/src/lib/select2.component.ts
+++ b/projects/ng-select2-component/src/lib/select2.component.ts
@@ -1094,7 +1094,7 @@ export class Select2 implements ControlValueAccessor, OnInit, DoCheck, AfterView
             this.selectByEnter(true);
             event.preventDefault();
         } else if (this.isSearchboxHidden && this._testKey(event, [' '])) {
-            return;
+            this.prevChange(event);
         } else if (this._testKey(event, CLOSE_KEYS) && this.isOpen) {
             this.toggleOpenAndClose();
             this._focus(true);

--- a/projects/ng-select2-component/src/lib/select2.component.vitest.ts
+++ b/projects/ng-select2-component/src/lib/select2.component.vitest.ts
@@ -1331,6 +1331,19 @@ describe('Select2 Component', () => {
             expect(host.onAutoCreate).not.toHaveBeenCalled();
         });
 
+        it('should not shift focus when typing text that contains space with multiple keydown events in autocreate mode', () => {
+            const createField = fixture.nativeElement.querySelector('.select2-create__field') as HTMLInputElement;
+            createField.click();
+            detectChanges(fixture);
+
+            createField.focus();
+            for (const char of 'foo bar') {
+                dispatchKeydown(createField, char);
+                detectChanges(fixture);
+                expect(document.activeElement).toBe(createField);
+            }
+        });
+
         it('should show searchbox when autoCreate and not multiple', () => {
             host.multiple = false;
             host.autoCreate = true;


### PR DESCRIPTION
This is still from #107 and it was an issue where returning from the statement still cause the focus to shift 